### PR TITLE
conf/mfcc_hires.conf

### DIFF
--- a/examples/wsj/conf/mfcc_hires.conf
+++ b/examples/wsj/conf/mfcc_hires.conf
@@ -1,0 +1,10 @@
+# config for high-resolution MFCC features, intended for neural network training
+# Note: we keep all cepstra, so it has the same info as filterbank features,
+# but MFCC is more easily compressible (because less correlated) which is why 
+# we prefer this method.
+--use-energy=false   # use average of log energy, not energy.
+--num-mel-bins=40     # similar to Google's setup.
+--num-ceps=40     # there is no dimensionality reduction.
+--low-freq=20     # low cutoff frequency for mel bins... this is high-bandwidth data, so
+                  # there might be some information at the low end.
+--high-freq=-400 # high cutoff frequently, relative to Nyquist of 8000 (=7600) 

--- a/examples/wsj/run.sh
+++ b/examples/wsj/run.sh
@@ -3,11 +3,12 @@
 
 # Apache 2.0
 
+. ./cmd.sh
 set -e -o pipefail
 
 stage=0
-ngpus=1 # num GPUs for multiple GPUs training within a single node; should match those in $free_gpu
-free_gpu= # comma-separated available GPU ids, eg., "0" or "0,1"; automatically assigned if on CLSP grid
+ngpus=4 # num GPUs for multiple GPUs training within a single node; should match those in $free_gpu
+free_gpu=0,1,2,3 # comma-separated available GPU ids, eg., "0" or "0,1"; automatically assigned if on CLSP grid
 
 # E2E model related
 affix=
@@ -18,8 +19,8 @@ treedir=data/graph  # contain numerator fst
 
 # data related
 dumpdir=data/dump   # directory to dump full features
-wsj0=
-wsj1=
+wsj0=/home/CORPUS/LDC/LDC93S6B
+wsj1=/home/CORPUS/LDC/LDC94S13B
 if [[ $(hostname -f) == *.clsp.jhu.edu ]]; then
   wsj0=/export/corpora5/LDC/LDC93S6B
   wsj1=/export/corpora5/LDC/LDC94S13B

--- a/examples/wsj/run.sh
+++ b/examples/wsj/run.sh
@@ -7,8 +7,8 @@
 set -e -o pipefail
 
 stage=0
-ngpus=4 # num GPUs for multiple GPUs training within a single node; should match those in $free_gpu
-free_gpu=0,1,2,3 # comma-separated available GPU ids, eg., "0" or "0,1"; automatically assigned if on CLSP grid
+ngpus=1 # num GPUs for multiple GPUs training within a single node; should match those in $free_gpu
+free_gpu= # comma-separated available GPU ids, eg., "0" or "0,1"; automatically assigned if on CLSP grid
 
 # E2E model related
 affix=
@@ -19,8 +19,8 @@ treedir=data/graph  # contain numerator fst
 
 # data related
 dumpdir=data/dump   # directory to dump full features
-wsj0=/home/CORPUS/LDC/LDC93S6B
-wsj1=/home/CORPUS/LDC/LDC94S13B
+wsj0=
+wsj1=
 if [[ $(hostname -f) == *.clsp.jhu.edu ]]; then
   wsj0=/export/corpora5/LDC/LDC93S6B
   wsj1=/export/corpora5/LDC/LDC94S13B


### PR DESCRIPTION
Hello,

conf/mfcc_hires.conf is needed to your wsj recipe.

It is copied from kaldi/egs/wsj/s5/conf.

Also, cmd.sh is required to stage 6.

Best regard, 

Hosung